### PR TITLE
Правки в deps

### DIFF
--- a/deps
+++ b/deps
@@ -75,13 +75,14 @@
     target=/bundles/Liip/FunctionalTestBundle
 
 [KnpMenuBundle]
-    git=https://github.com/knplabs/KnpMenuBundle.git
+    git=http://github.com/KnpLabs/KnpMenuBundle.git
     target=bundles/Knp/Bundle/MenuBundle
     version=legacy
 
 [PaginatorBundle]
-    git=http://github.com/knplabs/KnpPaginatorBundle.git
+    git=http://github.com/KnpLabs/KnpPaginatorBundle.git
     target=/bundles/Knp/Bundle/PaginatorBundle
+	version=v1.0
 
 [SensioDistributionBundle]
     git=http://github.com/sensio/SensioDistributionBundle.git
@@ -91,11 +92,12 @@
 [SensioFrameworkExtraBundle]
     git=http://github.com/sensio/SensioFrameworkExtraBundle.git
     target=/bundles/Sensio/Bundle/FrameworkExtraBundle
+	version=origin/2.0
 
 [SensioGeneratorBundle]
     git=http://github.com/sensio/SensioGeneratorBundle.git
     target=/bundles/Sensio/Bundle/GeneratorBundle
 
 [ZendCacheBundle]
-    git=http://github.com/knplabs/KnpZendCacheBundle.git
+    git=http://github.com/KnpLabs/KnpZendCacheBundle.git
     target=/bundles/Knp/Bundle/ZendCacheBundle


### PR DESCRIPTION
1. KnpLabs изменили пути к репозиториям поэтому Menu, Paginator не хотели устанавливаться
2. Версия KnpPaginator"а которая в ветке master работает только с веткой master Symfony, так как у нас стабильный релиз из 2.0.х то для него они предлагают другую версию.
3. Тоже самое и с Sensio FrameworkExtraBundle

эти правки я внес в файл deps. 
